### PR TITLE
Exit when a command finishes with failure

### DIFF
--- a/src/components.rs
+++ b/src/components.rs
@@ -15,6 +15,25 @@ pub enum Arch {
     Aarch64,
 }
 
+fn run_command(cvd_dir: &str, name: &str, args: Vec<String>, envs: &HashMap<String, String>) {
+    match Command::new(format!("{cvd_dir}/bin/{name}"))
+        .args(&args)
+        .envs(envs)
+        .stderr(std::process::Stdio::inherit())
+        .output()
+    {
+        Ok(_output) => {}
+        Err(err) => {
+            if err.kind() == std::io::ErrorKind::NotFound {
+                println!("Can't find {name} in {cvd_dir}");
+            } else {
+                println!("Error executing {name}: {}", err);
+            }
+            std::process::exit(-1);
+        }
+    };
+}
+
 fn call_simg2img(
     cvd_dir: &str,
     envs: &HashMap<String, String>,
@@ -24,22 +43,7 @@ fn call_simg2img(
     let tmp = format!("{cvd_dir}/{image}.tmp");
     let args = vec![src.clone(), tmp.clone()];
 
-    match Command::new(format!("{cvd_dir}/bin/simg2img"))
-        .args(&args)
-        .envs(envs)
-        .stderr(std::process::Stdio::inherit())
-        .output()
-    {
-        Ok(output) => output,
-        Err(err) => {
-            if err.kind() == std::io::ErrorKind::NotFound {
-                println!("Can't find simg2img in {cvd_dir}");
-            } else {
-                println!("Error executing simg2img: {}", err);
-            }
-            std::process::exit(-1);
-        }
-    };
+    run_command(cvd_dir, "simg2img", args, envs);
 
     std::fs::rename(tmp, src)
 }
@@ -89,22 +93,7 @@ pub fn create_uboot(
     f.write_all(uboot_env_input_data)?;
     drop(f);
 
-    match Command::new(format!("{cvd_dir}/bin/mkenvimage_slim"))
-        .args(&args)
-        .envs(envs)
-        .stderr(std::process::Stdio::inherit())
-        .output()
-    {
-        Ok(output) => output,
-        Err(err) => {
-            if err.kind() == std::io::ErrorKind::NotFound {
-                println!("Can't find mkenvimage_slim in {cvd_dir}");
-            } else {
-                println!("Error executing mkenvimage_slim: {}", err);
-            }
-            std::process::exit(-1);
-        }
-    };
+    run_command(cvd_dir, "mkenvimage_slim", args, envs);
 
     let args = vec![
         "add_hash_footer".to_string(),
@@ -120,22 +109,7 @@ pub fn create_uboot(
         "SHA256_RSA4096".to_string(),
     ];
 
-    match Command::new(format!("{cvd_dir}/bin/avbtool"))
-        .args(&args)
-        .envs(envs)
-        .stderr(std::process::Stdio::inherit())
-        .output()
-    {
-        Ok(output) => output,
-        Err(err) => {
-            if err.kind() == std::io::ErrorKind::NotFound {
-                println!("Can't find avbtool in {cvd_dir}");
-            } else {
-                println!("Error executing avbtool: {}", err);
-            }
-            std::process::exit(-1);
-        }
-    };
+    run_command(cvd_dir, "avbtool", args, envs);
 
     Ok(())
 }
@@ -161,22 +135,7 @@ pub fn create_vbmeta(
         "SHA256_RSA4096".to_string(),
     ];
 
-    match Command::new(format!("{cvd_dir}/bin/avbtool"))
-        .args(&args)
-        .envs(envs)
-        .stderr(std::process::Stdio::inherit())
-        .output()
-    {
-        Ok(output) => output,
-        Err(err) => {
-            if err.kind() == std::io::ErrorKind::NotFound {
-                println!("Can't find avbtool in {cvd_dir}");
-            } else {
-                println!("Error executing avbtool: {}", err);
-            }
-            std::process::exit(-1);
-        }
-    };
+    run_command(cvd_dir, "avbtool", args, envs);
 
     let mut f = OpenOptions::new().write(true).open(vbmeta_path)?;
     let metdata = f.metadata()?;
@@ -260,22 +219,7 @@ androidboot.hardware.hwcomposer.mode=client
         "SHA256_RSA4096".to_string(),
     ];
 
-    match Command::new(format!("{cvd_dir}/bin/avbtool"))
-        .args(&args)
-        .envs(envs)
-        .stderr(std::process::Stdio::inherit())
-        .output()
-    {
-        Ok(output) => output,
-        Err(err) => {
-            if err.kind() == std::io::ErrorKind::NotFound {
-                println!("Can't find avbtool in {cvd_dir}");
-            } else {
-                println!("Error executing avbtool: {}", err);
-            }
-            std::process::exit(-1);
-        }
-    };
+    run_command(cvd_dir, "avbtool", args, envs);
 
     Ok(())
 }


### PR DESCRIPTION
If an external command finishes with a non-zero exit code, cvd2img should stop
further processing.  It makes no sense to continue after a failure, it's just
wasteful and increases the chances of overlooking the error.
